### PR TITLE
Adding sample support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Video and sound examples:
 - Simple 16-step sequencer: press space to toggle a step, and on bass and piano lines, repeat it to choose a different note.
 - Bad approxmiations of classic roland 808 and 909 sounds: Bass Drum, Snare, Low- Mid- and High-Toms, Clap, Cowbell, Hihat and Open Hihat, all done in code, no samples.
 - A simplistic bassline sequencer allowing octave jumps of a square wave
-- Toggle between 808 and 909 kits while playing
+- Cycle between generated 808  and 909 kits, or local samples while playing
 - Configurable lowpass filter for the bass sequence
 - A ...piano(?) sound. Another sound. Plays some variation on Am7
 - Per-channel mute and un-mutes

--- a/main.py
+++ b/main.py
@@ -409,7 +409,7 @@ try:
                     + {"x": "o", "o": "x"}[GRID[CURSOR[0]][CURSOR[1]]]
                     + GRID[CURSOR[0]][CURSOR[1] + 1:]
                 )
-        elif c in (ord("8"), ord("9")):
+        elif c == ord("8"):
             if CURRENT_KIT == "808":
                 CURRENT_KIT = "909"
             elif CURRENT_KIT == "909":

--- a/main.py
+++ b/main.py
@@ -7,6 +7,11 @@ import threading
 import random
 import json
 import os
+import librosa
+import soundfile as sf
+
+current_dir = os.path.dirname(os.path.realpath(__file__))
+
 
 IS_EXITING = False
 
@@ -25,14 +30,19 @@ PLAYBACK_THREAD = None
 CURRENT_KIT = "808"
 BASSLINE_FILTER_FREQ = 880.0
 SLIDE_AMT = 0.1
+SAMPLES_PATH = os.path.join(current_dir, "samples/") # Modify "samples/" to your samples folder relative path
 
 
 class Instrument:
-    def __init__(self, label, sound, level):
+    def __init__(self, label, sound, level, file_name=None):  # Add file_name parameter
         self.label = label
         self.sound = sound
         self.level = level
+        self.file_name = file_name  # Add file_name attribute
 
+    def load_sound(self):
+        if self.file_name is not None:
+            self.sound = load_sample(os.path.join(SAMPLES_PATH, self.file_name))
 
 def generate_sound(freq, decay_factor, length, noise=False):
     x = np.arange(length)
@@ -117,6 +127,22 @@ def generate_piano_chord(root_freq, decay_factor, length):
     decay = np.exp(-decay_factor * np.arange(length))
     return (chord * decay).astype(np.float32)
 
+def get_instruments():
+    if CURRENT_KIT == "808":
+        return INSTRUMENTS_808
+    elif CURRENT_KIT == "909":
+        return INSTRUMENTS_909
+    elif CURRENT_KIT == "SMP":
+        return INSTRUMENTS_SMP
+
+def load_sample(file_path):
+    try:
+        data, _ = librosa.load(file_path, sr=FS)
+        return data
+    except Exception:
+        # print(f"Failed to load sample: {file_path}")
+        return np.zeros(int(FS * BPMFRAME), dtype=np.float32)  # return an array of zeros
+
 
 KICK_808 = generate_kick_sound(65.0, 50.0, 0.0003, int(FS * 0.4))
 SNARE_808 = generate_sound(180.0, 0.0015, int(FS * BPMFRAME))
@@ -179,6 +205,21 @@ INSTRUMENTS_909 = [
     Instrument("♪ PA", None, 0.8),
 ]
 
+INSTRUMENTS_SMP = [
+    Instrument("⦿ BD", None, 0.8, "bd.wav"),
+    Instrument("◼ SD", None, 1.0, "sd.wav"),
+    Instrument("⚆ LT", None, 0.8, "lt.wav"),
+    Instrument("⚇ MT", None, 0.7, "mt.wav"),
+    Instrument("⚈ HT", None, 0.9, "ht.wav"),
+    Instrument("॥ CP", None, 0.6, "cp.wav"),
+    Instrument("Ⓚ CB", None, 1.0, "cb.wav"),
+    Instrument("⨂ HH", None, 1.0, "hh.wav"),
+    Instrument("⨁ OH", None, 1.0, "oh.wav"),
+    Instrument("♩ BL", None, 0.2),
+    Instrument("♪ PA", None, 0.8),
+]
+for inst in INSTRUMENTS_SMP:
+    inst.load_sound()
 
 stdscr = curses.initscr()
 curses.noecho()
@@ -240,8 +281,7 @@ piano_freqs = [262, 330, 440]  # frequencies for C4, E4, A4 notes
 def update_sequence():
     dump_sequence()
     global COMPLETE_SEQUENCE, instruments
-    instruments = INSTRUMENTS_808 if CURRENT_KIT == "808" else INSTRUMENTS_909
-
+    instruments = get_instruments()
     sequences = []
     for j in range(len(instruments)):
         if INSTRUMENT_MUTE_STATUS.get(j, False):
@@ -332,7 +372,7 @@ try:
         stdscr.addstr(
             len(GRID) + 1,
             0,
-            f'Move with (arrows), press (space) to toggle a step, (x) to clear the pattern\n\n⇧/(-/=) BPM: {BPM}\n⇧/(5/6/0) Swing: {SWING}%\n(8/9): Selected Kit: {CURRENT_KIT}\n(s): Status: {"Playing" if PLAYBACK_THREAD else "Stopped"}\n(f/g): Bass Filter Freq: {BASSLINE_FILTER_FREQ}\n(o/p): Slide Amount: {SLIDE_AMT * 100}%\n(m): Mute/Unmute Track\n\n(q) to quit',
+            f'Move with (arrows), press (space) to toggle a step, (x) to clear the pattern\n\n⇧/(-/=) BPM: {BPM}\n⇧/(5/6/0) Swing: {SWING}%\n(8): Selected Kit: {CURRENT_KIT}\n(s): Status: {"Playing" if PLAYBACK_THREAD else "Stopped"}\n(f/g): Bass Filter Freq: {BASSLINE_FILTER_FREQ}\n(o/p): Slide Amount: {SLIDE_AMT * 100}%\n(m): Mute/Unmute Track\n\n(q) to quit',
         )
 
         stdscr.move(
@@ -370,10 +410,21 @@ try:
                     + GRID[CURSOR[0]][CURSOR[1] + 1:]
                 )
         elif c in (ord("8"), ord("9")):
-            CURRENT_KIT = {ord("8"): "808", ord("9"): "909"}[c]
-        elif c in (ord("8"), ord("9")):
-            CURRENT_KIT = {ord("8"): "808", ord("9"): "909"}[c]
-            instruments = INSTRUMENTS_808 if CURRENT_KIT == "808" else INSTRUMENTS_909
+            if CURRENT_KIT == "808":
+                CURRENT_KIT = "909"
+            elif CURRENT_KIT == "909":
+                CURRENT_KIT = "SMP"
+                # Reload the samples every time you switch to the "SMP" kit
+                for inst in INSTRUMENTS_SMP:
+                    inst.load_sound()  # Use the load_sound method
+            else:
+                CURRENT_KIT = "808"
+            if CURRENT_KIT == "808":
+                instruments = INSTRUMENTS_808
+            elif CURRENT_KIT == "909":
+                instruments = INSTRUMENTS_909
+            elif CURRENT_KIT == "SMP":
+                instruments = INSTRUMENTS_SMP
         elif c == ord("0") or c == ord(")"):  # handle shift for resetting
             SWING = 50
         elif c == ord("5"):


### PR DESCRIPTION
This adds support for wavform samples.

This adds a new kit, "SMP" which loads samples in the local samples/ directory with the following names

bd.wav
cb.wav
cp.wav
hh.wav
ht.wav
lt.wav
mt.wav
oh.wav
sd.wav

Attached is an example set.

If the sound cannot be found or loaded, it will play silence.

[samples.zip](https://github.com/ProfessionalDevelopers/TR-CVC/files/12053368/samples.zip)
